### PR TITLE
Fix pie chart on statistics page

### DIFF
--- a/app/src/main/res/layout/fragment_statistics.xml
+++ b/app/src/main/res/layout/fragment_statistics.xml
@@ -151,51 +151,59 @@
             tools:text="@string/most_active_client_placeholder" />
 
         <!-- Графики -->
-        <com.github.mikephil.charting.charts.BarChart
-            android:id="@+id/bar_chart_appointments"
+        <!-- Контейнер для барной диаграммы -->
+        <FrameLayout
+            android:id="@+id/bar_chart_container"
             android:layout_width="0dp"
             android:layout_height="300dp"
             android:layout_marginTop="24dp"
             app:layout_constraintTop_toBottomOf="@id/text_view_most_active_client"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            app:layout_constraintEnd_toEndOf="parent">
 
-        <TextView
-            android:id="@+id/text_view_no_bar_chart_data"
+            <com.github.mikephil.charting.charts.BarChart
+                android:id="@+id/bar_chart_appointments"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
+            <TextView
+                android:id="@+id/text_view_no_bar_chart_data"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:text="@string/no_chart_data_appointments"
+                android:textSize="16sp"
+                android:textColor="@android:color/darker_gray"
+                android:visibility="gone" />
+
+        </FrameLayout>
+
+        <!-- Контейнер для круговой диаграммы -->
+        <FrameLayout
+            android:id="@+id/pie_chart_container"
             android:layout_width="0dp"
             android:layout_height="300dp"
             android:layout_marginTop="24dp"
-            android:gravity="center"
-            android:text="@string/no_chart_data_appointments"
-            android:textSize="16sp"
-            android:textColor="@android:color/darker_gray"
-            android:visibility="gone"
-            app:layout_constraintTop_toBottomOf="@id/text_view_most_active_client"
+            app:layout_constraintTop_toBottomOf="@id/bar_chart_container"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            app:layout_constraintEnd_toEndOf="parent">
 
-        <com.github.mikephil.charting.charts.PieChart
-            android:id="@+id/pie_chart_revenue_by_category"
-            android:layout_width="0dp"
-            android:layout_height="300dp"
-            android:layout_marginTop="24dp"
-            app:layout_constraintTop_toBottomOf="@id/bar_chart_appointments"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            <com.github.mikephil.charting.charts.PieChart
+                android:id="@+id/pie_chart_revenue_by_category"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
 
-        <TextView
-            android:id="@+id/text_view_no_pie_chart_data"
-            android:layout_width="0dp"
-            android:layout_height="300dp"
-            android:layout_marginTop="24dp"
-            android:gravity="center"
-            android:text="@string/no_chart_data_revenue"
-            android:textSize="16sp"
-            android:textColor="@android:color/darker_gray"
-            android:visibility="gone"
-            app:layout_constraintTop_toBottomOf="@id/pie_chart_revenue_by_category"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            <TextView
+                android:id="@+id/text_view_no_pie_chart_data"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:text="@string/no_chart_data_revenue"
+                android:textSize="16sp"
+                android:textColor="@android:color/darker_gray"
+                android:visibility="gone" />
+
+        </FrameLayout>
 
         <!-- Кнопки бэкапа -->
         <Button
@@ -204,7 +212,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="32dp"
             android:text="@string/backup_button"
-            app:layout_constraintTop_toBottomOf="@id/text_view_no_pie_chart_data"
+            app:layout_constraintTop_toBottomOf="@id/pie_chart_container"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -20,6 +20,7 @@
     <color name="blue_500">#2196F3</color>
     <color name="blue_700">#1976D2</color>
     <color name="lavender_booked_slot">#9370DB</color>
+    <color name="colorBookedSlot">#9370DB</color>
     <color name="colorFreeSlot">#E0E0E0</color>
     <color name="colorPastSlot">#B0BEC5</color>
     <color name="grey_text_disabled">#757575</color>


### PR DESCRIPTION
Refactor statistics layout and add missing color to fix pie chart display.

The pie chart was not visible due to conflicting `ConstraintLayout` constraints where the chart and its 'no data' message occupied the same space. Additionally, the backup button's constraint was incorrectly tied to the hidden 'no data' element. Wrapping charts in `FrameLayout`s resolves these positioning issues and ensures correct visibility toggling. A missing color resource (`colorBookedSlot`) was also added.